### PR TITLE
suppress spurious messages

### DIFF
--- a/include/rtw_debug.h
+++ b/include/rtw_debug.h
@@ -313,15 +313,15 @@ extern u32 GlobalDebugLevel;
 #if     defined (_dbgdump)
         #undef DBG_871X
 //      #define DBG_871X _dbgdump
-        #define DBG_871X(...) LOG_LEVEL(_drv_emerg_ , __VA_ARGS__)
+        #define DBG_871X(...) LOG_LEVEL(_drv_debug_ , __VA_ARGS__)
 
         #undef MSG_8192C
 //      #define MSG_8192C _dbgdump
-        #define MSG_8192C(...) LOG_LEVEL(_drv_emerg_ , __VA_ARGS__)
+        #define MSG_8192C(...) LOG_LEVEL(_drv_info_ , __VA_ARGS__)
 
         #undef DBG_8192C
 //      #define DBG_8192C _dbgdump
-        #define DBG_8192C(...) LOG_LEVEL(_drv_emerg_ ,  __VA_ARGS__)
+        #define DBG_8192C(...) LOG_LEVEL(_drv_debug_ ,  __VA_ARGS__)
 
 
 	#undef WRN_8192C


### PR DESCRIPTION
EDIT: spurious is completely the wrong word

This is a tiny patch I've been using for a while at home, before I heard of pvaret's project. A DBG macro was generating messages as if they were errors rather than debug messages (i.e. all the time) and it was spewing all over the active terminal whenever some kind of power management event was happening.

The diff is pretty self explanatory even to someone who's never seen the code before, but I appreciate there may be some odd reason lurking in there somewhere for not applying this patch after all.

Yours sincerely,
Professor Poop