### PR TITLE
Add ProductId for the Netgear N150 - WNA1000M

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -112,6 +112,7 @@ static void rtw_dev_remove(struct usb_interface *pusb_intf);
 	{USB_DEVICE(0x4856, 0x0091)},/* NetweeN - Feixun */ \
 	{USB_DEVICE(0x0846, 0x9041)}, /* Netgear - Cameo */ \
 	{USB_DEVICE(0x0846, 0x9042)}, /* On Networks - N150MA */ \
+	{USB_DEVICE(0x0846, 0x9043)}, /* Netgear N150 -WNA1000M */ \
 	{USB_DEVICE(0x2019, 0x4902)},/* Planex - Etop */ \
 	{USB_DEVICE(0x2019, 0xAB2E)},/* SW-WF02-AD15 -Abocom */ \
 	{USB_DEVICE(0x2001, 0x330B)}, /* D-LINK - T&W */ \


### PR DESCRIPTION
This pull-request only adds the productId for the netgear N150 - WNA1000M (see : http://www.netgear.fr/home/products/networking/wifi-adapters/WNA1000M.aspx , v2 of this device has an incremented productId 9043 )

```bash
dmesg :
usb 5-1: new high-speed USB device number 6 using ehci-pci
usb 5-1: New USB device found, idVendor=0846, idProduct=9043
usb 5-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
usb 5-1: Product: WNA1000Mv2
usb 5-1: Manufacturer: Realtek
usb 5-1: SerialNumber: 00e04c000001
```

Just tested on Debian with kernel 3.16

