### PR TITLE
Include net/ip6_checksum.h which is needed by csum_ipv6_magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Compatibility
 These devices are known to work with this driver:
 - ASUSTek USB-N13 **rev. B1** (0b05:17ab)
 - Belkin N300
+- Edimax EW-7811Un (7392:7811)
 - TP-Link TL-WN822N (0bda:8178)
 - TP-Link TL-WN823N
 - TRENDnet TEW-648UBM N150

--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -51,6 +51,7 @@
 #include <linux/icmpv6.h>
 #include <net/ndisc.h>
 #include <net/checksum.h>
+#include <net/ip6_checksum.h>
 #endif
 #endif
 


### PR DESCRIPTION
csum_ipv6_magic function is defined in net/ip6_checksum.h, and is
missing in rtw_br_ext.c. This cause the kernel module failed to build
on arm64 platform. Other platforms like x86 can build without problem
because the csum_ipv6_magic function are defined in arch specific
asm/checksum.h, which is missing on arm64 platform.