### PR TITLE
Merge in changes for kernel 4.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/pvaret/rtl8192cu-fixes.svg?branch=master)](https://travis-ci.org/pvaret/rtl8192cu-fixes)
-
 This is a repackaging of Realtek's own 8192CU USB WiFi driver for Ubuntu 13.10 and later.
 
 !! This driver is DEPRECATED !!
@@ -10,6 +8,13 @@ The new `rtl8xxxu` driver initially introduced in kernel 4.4 works pretty well t
 If `rtl8xxxu` gives you problems, try troubleshooting it before installing this driver. Known things to look for are:
   - Some devices require that power management be disabled in NetworkManager. Follow the instructions further down to disable power management in NetworkManager.
   - Make sure to blacklist the older `rtl8192cu` driver, which tends to be loaded by default otherwise.
+
+That said, I still believe this driver to be the best performing option for many devices, including and especially many 8192cu usb dongles.  So I have forked pvaret's 8192cu driver found here:
+
+https://github.com/pvaret/rtl8192cu-fixes
+
+and patched for kernel 4.15.0.  So far performance equals that of pre 4.15.0 kernels with no drops or disconnects as can frequently be experienced with the in-kernel rtl8192cu and rtl8xxxu drivers.
+
 
 Compatibility
 =============

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This is a repackaging of Realtek's own 8192CU USB WiFi driver for Ubuntu 13.10 and later.
+This is a repackaging of Realtek's own 8192CU USB WiFi driver for kernel 4.15.0.
 
 !! This driver is DEPRECATED !!
 ===============================
 
-The new `rtl8xxxu` driver initially introduced in kernel 4.4 works pretty well these days, and you almost certainly should prefer it to this repository.
+The new `rtl8xxxu` driver initially introduced in kernel 4.4 works pretty well these days, with some exceptions, but you should try it before trying this repository.
 
 If `rtl8xxxu` gives you problems, try troubleshooting it before installing this driver. Known things to look for are:
   - Some devices require that power management be disabled in NetworkManager. Follow the instructions further down to disable power management in NetworkManager.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a repackaging of Realtek's own 8192CU USB WiFi driver for kernel 4.15.0.
+This is a repackaging of Realtek's own 8192CU USB WiFi driver for **kernel 4.15.0.**
 
 !! This driver is DEPRECATED !!
 ===============================
@@ -9,11 +9,11 @@ If `rtl8xxxu` gives you problems, try troubleshooting it before installing this 
   - Some devices require that power management be disabled in NetworkManager. Follow the instructions further down to disable power management in NetworkManager.
   - Make sure to blacklist the older `rtl8192cu` driver, which tends to be loaded by default otherwise.
 
-That said, I still believe this driver to be the best performing option for many devices, including and especially many 8192cu usb dongles.  So I have forked pvaret's 8192cu driver found here:
+**That said, I still believe this driver to be the best performing option for many devices, including and especially many 8192cu usb dongles.  So I have forked pvaret's 8192cu driver found here:**
 
 https://github.com/pvaret/rtl8192cu-fixes
 
-and patched for kernel 4.15.0.  So far performance equals that of pre 4.15.0 kernels with no drops or disconnects as can frequently be experienced with the in-kernel rtl8192cu and rtl8xxxu drivers.
+**and patched for kernel 4.15.0.  So far performance equals that of pre 4.15.0 kernels with no drops or disconnects as can frequently be experienced with the in-kernel rtl8192cu and rtl8xxxu drivers.**
 
 
 Compatibility

--- a/core/rtw_p2p.c
+++ b/core/rtw_p2p.c
@@ -4692,9 +4692,17 @@ _func_exit_;
 }
 #endif // CONFIG_P2P_PS
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 static void reset_ch_sitesurvey_timer_process (void *FunctionContext)
+#else
+static void reset_ch_sitesurvey_timer_process(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, wdinfo.reset_ch_sitesurvey);
+#endif
 	struct	wifidirect_info		*pwdinfo = &adapter->wdinfo;
 
 	if(rtw_p2p_chk_state(pwdinfo, P2P_STATE_NONE))
@@ -4711,9 +4719,17 @@ static void reset_ch_sitesurvey_timer_process (void *FunctionContext)
 	pwdinfo->rx_invitereq_info.scan_op_ch_only = 0;
 }
 
-static void reset_ch_sitesurvey_timer_process2 (void *FunctionContext)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+static void reset_ch_sitesurvey_timer_process2(void *FunctionContext)
+#else
+static void reset_ch_sitesurvey_timer_process2(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, wdinfo.reset_ch_sitesurvey2);
+#endif
 	struct	wifidirect_info		*pwdinfo = &adapter->wdinfo;
 
 	if(rtw_p2p_chk_state(pwdinfo, P2P_STATE_NONE))
@@ -4730,9 +4746,17 @@ static void reset_ch_sitesurvey_timer_process2 (void *FunctionContext)
 	pwdinfo->p2p_info.scan_op_ch_only = 0;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 static void restore_p2p_state_timer_process (void *FunctionContext)
+#else
+static void restore_p2p_state_timer_process(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, wdinfo.restore_p2p_state_timer);
+#endif
 	struct	wifidirect_info		*pwdinfo = &adapter->wdinfo;
 
 	if(rtw_p2p_chk_state(pwdinfo, P2P_STATE_NONE))
@@ -4741,9 +4765,17 @@ static void restore_p2p_state_timer_process (void *FunctionContext)
 	p2p_protocol_wk_cmd( adapter, P2P_RESTORE_STATE_WK );
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 static void pre_tx_scan_timer_process (void *FunctionContext)
+#else
+static void pre_tx_scan_timer_process(struct timer_list *t)
+#endif
 {
-	_adapter 							*adapter = (_adapter *) FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *) FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, wdinfo.pre_tx_scan_timer);
+#endif
 	struct	wifidirect_info				*pwdinfo = &adapter->wdinfo;
 	_irqL							irqL;
 	struct mlme_priv					*pmlmepriv = &adapter->mlmepriv;
@@ -4790,9 +4822,17 @@ static void pre_tx_scan_timer_process (void *FunctionContext)
 	_exit_critical_bh(&pmlmepriv->lock, &irqL);
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 static void find_phase_timer_process (void *FunctionContext)
+#else
+static void find_phase_timer_process(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, wdinfo.find_phase_timer);
+#endif
 	struct	wifidirect_info		*pwdinfo = &adapter->wdinfo;
 
 	if(rtw_p2p_chk_state(pwdinfo, P2P_STATE_NONE))
@@ -4804,9 +4844,17 @@ static void find_phase_timer_process (void *FunctionContext)
 }
 
 #ifdef CONFIG_CONCURRENT_MODE
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 void ap_p2p_switch_timer_process (void *FunctionContext)
+#else
+void ap_p2p_switch_timer_process(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, wdinfo.ap_p2p_switch_timer);
+#endif
 	struct	wifidirect_info		*pwdinfo = &adapter->wdinfo;
 #ifdef CONFIG_IOCTL_CFG80211	
 	struct rtw_wdev_priv *pwdev_priv = wdev_to_priv(adapter->rtw_wdev);
@@ -4863,6 +4911,7 @@ void rtw_init_wifidirect_timers(_adapter* padapter)
 {
 	struct wifidirect_info *pwdinfo = &padapter->wdinfo;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 	_init_timer( &pwdinfo->find_phase_timer, padapter->pnetdev, find_phase_timer_process, padapter );
 	_init_timer( &pwdinfo->restore_p2p_state_timer, padapter->pnetdev, restore_p2p_state_timer_process, padapter );
 	_init_timer( &pwdinfo->pre_tx_scan_timer, padapter->pnetdev, pre_tx_scan_timer_process, padapter );
@@ -4870,6 +4919,16 @@ void rtw_init_wifidirect_timers(_adapter* padapter)
 	_init_timer( &pwdinfo->reset_ch_sitesurvey2, padapter->pnetdev, reset_ch_sitesurvey_timer_process2, padapter );
 #ifdef CONFIG_CONCURRENT_MODE
 	_init_timer( &pwdinfo->ap_p2p_switch_timer, padapter->pnetdev, ap_p2p_switch_timer_process, padapter );
+#endif
+#else
+        timer_setup(&pwdinfo->find_phase_timer, find_phase_timer_process, 0);
+        timer_setup(&pwdinfo->restore_p2p_state_timer, restore_p2p_state_timer_process, 0);
+        timer_setup(&pwdinfo->pre_tx_scan_timer, pre_tx_scan_timer_process, 0);
+        timer_setup(&pwdinfo->reset_ch_sitesurvey, reset_ch_sitesurvey_timer_process, 0);
+        timer_setup(&pwdinfo->reset_ch_sitesurvey2, reset_ch_sitesurvey_timer_process2, 0);
+#ifdef CONFIG_CONCURRENT_MODE
+        timer_setup(&pwdinfo->ap_p2p_switch_timer, ap_p2p_switch_timer_process, 0);
+#endif
 #endif
 }
 
@@ -5260,8 +5319,13 @@ int rtw_p2p_enable(_adapter *padapter, enum P2P_ROLE role)
 			_cancel_timer_ex( &pwdinfo->pre_tx_scan_timer);
 			_cancel_timer_ex( &pwdinfo->reset_ch_sitesurvey);
 			_cancel_timer_ex( &pwdinfo->reset_ch_sitesurvey2);
-			reset_ch_sitesurvey_timer_process( padapter );
-			reset_ch_sitesurvey_timer_process2( padapter );
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+                        reset_ch_sitesurvey_timer_process( padapter );
+                        reset_ch_sitesurvey_timer_process2( padapter );
+#else
+                        reset_ch_sitesurvey_timer_process(&padapter->wdinfo.reset_ch_sitesurvey);
+                        reset_ch_sitesurvey_timer_process(&padapter->wdinfo.reset_ch_sitesurvey2);
+#endif
 			#ifdef CONFIG_CONCURRENT_MODE			
 			_cancel_timer_ex( &pwdinfo->ap_p2p_switch_timer);
 			#endif

--- a/core/rtw_pwrctrl.c
+++ b/core/rtw_pwrctrl.c
@@ -290,11 +290,18 @@ exit:
 	return;
 }
 
-void pwr_state_check_handler(void *FunctionContext);
-void pwr_state_check_handler(void *FunctionContext)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+void pwr_state_check_handler(RTW_TIMER_HDL_ARGS)
+#else
+void pwr_state_check_handler(struct timer_list *t)
+#endif
 {
-	_adapter *padapter = (_adapter *)FunctionContext;
-	rtw_ps_cmd(padapter);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *padapter = (_adapter *)FunctionContext;
+#else
+        _adapter *padapter = from_timer(padapter, t, pwrctrlpriv.pwr_state_check_timer);
+#endif
+        rtw_ps_cmd(padapter);
 }
 #endif
 
@@ -1108,7 +1115,11 @@ _func_enter_;
 	pwrctrlpriv->tog = 0x80;
 
 #ifdef PLATFORM_LINUX
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 	_init_timer(&(pwrctrlpriv->pwr_state_check_timer), padapter->pnetdev, pwr_state_check_handler, (u8 *)padapter);
+#else
+	timer_setup(&pwrctrlpriv->pwr_state_check_timer, pwr_state_check_handler, 0);
+#endif
 #endif
 
 	#ifdef CONFIG_RESUME_IN_WORKQUEUE

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -41,7 +41,12 @@
 #include <circ_buf.h>
 
 #ifdef CONFIG_NEW_SIGNAL_STAT_PROCESS
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 void rtw_signal_stat_timer_hdl(RTW_TIMER_HDL_ARGS);
+#else
+void rtw_signal_stat_timer_hdl(struct timer_list *t);
+#endif
+
 #endif //CONFIG_NEW_SIGNAL_STAT_PROCESS
 
 
@@ -134,7 +139,11 @@ _func_enter_;
 
 #ifdef CONFIG_NEW_SIGNAL_STAT_PROCESS
 	#ifdef PLATFORM_LINUX
-	_init_timer(&precvpriv->signal_stat_timer, padapter->pnetdev, RTW_TIMER_HDL_NAME(signal_stat), padapter);
+		#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+			_init_timer(&precvpriv->signal_stat_timer, padapter->pnetdev, RTW_TIMER_HDL_NAME(signal_stat), padapter);
+		#else
+			timer_setup(&precvpriv->signal_stat_timer, RTW_TIMER_HDL_NAME(signal_stat), 0);
+		#endif
 	#elif defined(PLATFORM_OS_CE) || defined(PLATFORM_WINDOWS)
 	_init_timer(&precvpriv->signal_stat_timer, padapter->hndis_adapter, RTW_TIMER_HDL_NAME(signal_stat), padapter);
 	#endif
@@ -4193,8 +4202,17 @@ _func_exit_;
 }
 
 #ifdef CONFIG_NEW_SIGNAL_STAT_PROCESS
-void rtw_signal_stat_timer_hdl(RTW_TIMER_HDL_ARGS){
-	_adapter *adapter = (_adapter *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+void rtw_signal_stat_timer_hdl(RTW_TIMER_HDL_ARGS)
+#else
+void rtw_signal_stat_timer_hdl(struct timer_list *t)
+#endif
+{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, recvpriv.signal_stat_timer);
+#endif
 	struct recv_priv *recvpriv = &adapter->recvpriv;
 	
 	u32 tmp_s, tmp_q;

--- a/hal/rtl8192c/rtl8192c_dm.c
+++ b/hal/rtl8192c/rtl8192c_dm.c
@@ -4606,7 +4606,9 @@ void rtl8192c_init_dm_priv(IN PADAPTER Adapter)
 	//_rtw_memset(pdmpriv, 0, sizeof(struct dm_priv));
 
 #ifdef CONFIG_SW_ANTENNA_DIVERSITY
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 	_init_timer(&(pdmpriv->SwAntennaSwitchTimer),  Adapter->pnetdev , dm_SW_AntennaSwitchCallback, Adapter);
+#endif
 #endif
 }
 

--- a/hal/rtl8192c/usb/rtl8192cu_led.c
+++ b/hal/rtl8192c/usb/rtl8192cu_led.c
@@ -48,15 +48,15 @@
 //================================================================================
 
 
-static void
-BlinkTimerCallback(
-	unsigned long data
-	);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+//static void BlinkTimerCallback(unsigned long data);
+void BlinkTimerCallback(unsigned long data);
+#else
+// static void BlinkTimerCallback(struct timer_list *t);
+void BlinkTimerCallback(struct timer_list *t);
+#endif
 
-static void
-BlinkWorkItemCallback(
-	struct work_struct *work
-	);
+static void BlinkWorkItemCallback(struct work_struct *work);
 
 //
 //	Description:
@@ -97,7 +97,11 @@ InitLed871x(
 
 	ResetLedStatus(pLed);
 
-	_init_timer(&(pLed->BlinkTimer), padapter->pnetdev, BlinkTimerCallback, pLed);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _init_timer(&(pLed->BlinkTimer), padapter->pnetdev, BlinkTimerCallback, pLed);
+#else
+        timer_setup(&pLed->BlinkTimer, BlinkTimerCallback, 0);
+#endif
 	_init_workitem(&(pLed->BlinkWorkItem), BlinkWorkItemCallback, pLed);
 }
 
@@ -1282,12 +1286,19 @@ SwLedBlink6(
 //		Callback function of LED BlinkTimer, 
 //		it just schedules to corresponding BlinkWorkItem.
 //
-static void
-BlinkTimerCallback(
-	unsigned long data
-	)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+// static void BlinkTimerCallback(void *data)
+void BlinkTimerCallback(void *data)
+#else
+// static void BlinkTimerCallback(struct timer_list *t)
+void BlinkTimerCallback(struct timer_list *t)
+#endif
 {
-	PLED_871x	 pLed = (PLED_871x)data;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        PLED_871x         pLed = (PLED_871x)data;
+#else
+        PLED_871x         pLed = from_timer(pLed, t, BlinkTimer);
+#endif
 	_adapter		*padapter = pLed->padapter;
 
 	//DBG_871X("%s\n", __FUNCTION__);

--- a/hal/rtl8192c/usb/rtl8192cu_led.c
+++ b/hal/rtl8192c/usb/rtl8192cu_led.c
@@ -49,10 +49,8 @@
 
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
-//static void BlinkTimerCallback(unsigned long data);
-void BlinkTimerCallback(unsigned long data);
+void BlinkTimerCallback(void *data);
 #else
-// static void BlinkTimerCallback(struct timer_list *t);
 void BlinkTimerCallback(struct timer_list *t);
 #endif
 
@@ -1287,16 +1285,12 @@ SwLedBlink6(
 //		it just schedules to corresponding BlinkWorkItem.
 //
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
-// static void BlinkTimerCallback(void *data)
-void BlinkTimerCallback(void *data)
-#else
-// static void BlinkTimerCallback(struct timer_list *t)
-void BlinkTimerCallback(struct timer_list *t)
-#endif
+void BlinkTimerCallback(void * data)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
         PLED_871x         pLed = (PLED_871x)data;
 #else
+void BlinkTimerCallback(struct timer_list *t)
+{
         PLED_871x         pLed = from_timer(pLed, t, BlinkTimer);
 #endif
 	_adapter		*padapter = pLed->padapter;

--- a/include/osdep_service.h
+++ b/include/osdep_service.h
@@ -955,6 +955,7 @@ __inline static void rtw_list_delete(_list *plist)
 	list_del_init(plist);
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 __inline static void _init_timer(_timer *ptimer,_nic_hdl nic_hdl,void *pfunc,void* cntx)
 {
 	//setup_timer(ptimer, pfunc,(u32)cntx);	
@@ -962,6 +963,7 @@ __inline static void _init_timer(_timer *ptimer,_nic_hdl nic_hdl,void *pfunc,voi
 	ptimer->data = (unsigned long)cntx;
 	init_timer(ptimer);
 }
+#endif
 
 __inline static void _set_timer(_timer *ptimer,u32 delay_time)
 {	

--- a/include/rtw_mlme.h
+++ b/include/rtw_mlme.h
@@ -639,8 +639,14 @@ extern void _rtw_scan_timeout_handler (
 
 #if defined (PLATFORM_LINUX)|| defined (PLATFORM_FREEBSD)
 extern int event_thread(void *context);
-extern void rtw_join_timeout_handler(void* FunctionContext);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+extern void rtw_join_timeout_handler(void *FunctionContext);
 extern void _rtw_scan_timeout_handler(void* FunctionContext);
+#else
+extern void rtw_join_timeout_handler(struct timer_list *t);
+extern void _rtw_scan_timeout_handler(struct timer_list *t);
+#endif
 #endif
 
 extern void rtw_free_network_queue(_adapter *adapter,u8 isfreeall);

--- a/os_dep/linux/mlme_linux.c
+++ b/os_dep/linux/mlme_linux.c
@@ -77,33 +77,64 @@ void sitesurvey_ctrl_handler(void *FunctionContext)
 }
 */
 
-void rtw_join_timeout_handler (void *FunctionContext)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+void rtw_join_timeout_handler(void *FunctionContext)
+#else
+void rtw_join_timeout_handler(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;
-	_rtw_join_timeout_handler(adapter);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, mlmepriv.assoc_timer);
+#endif
+
+        _rtw_join_timeout_handler(adapter);
 }
 
 
-void _rtw_scan_timeout_handler (void *FunctionContext)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+void _rtw_scan_timeout_handler(void *FunctionContext)
+#else
+void _rtw_scan_timeout_handler(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;
-	rtw_scan_timeout_handler(adapter);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, mlmepriv.scan_to_timer);
+#endif
+        rtw_scan_timeout_handler(adapter);
 }
 
-
-void _dynamic_check_timer_handlder (void *FunctionContext)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+static void _dynamic_check_timer_handlder(void *FunctionContext)
+#else
+static void _dynamic_check_timer_handlder(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;
-		 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, mlmepriv.dynamic_chk_timer);
+#endif
 	rtw_dynamic_check_timer_handlder(adapter);
-	
+
 	_set_timer(&adapter->mlmepriv.dynamic_chk_timer, 2000);
 }
 
 #ifdef CONFIG_SET_SCAN_DENY_TIMER
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 void _rtw_set_scan_deny_timer_hdl(void *FunctionContext)
+#else
+void _rtw_set_scan_deny_timer_hdl(struct timer_list *t)
+#endif
 {
-	_adapter *adapter = (_adapter *)FunctionContext;	 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *adapter = (_adapter *)FunctionContext;
+#else
+        _adapter *adapter = from_timer(adapter, t, mlmepriv.set_scan_deny_timer);
+#endif
 	rtw_set_scan_deny_timer_hdl(adapter);
 }
 #endif
@@ -113,15 +144,21 @@ void rtw_init_mlme_timer(_adapter *padapter)
 {
 	struct	mlme_priv *pmlmepriv = &padapter->mlmepriv;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 	_init_timer(&(pmlmepriv->assoc_timer), padapter->pnetdev, rtw_join_timeout_handler, padapter);
-	//_init_timer(&(pmlmepriv->sitesurveyctrl.sitesurvey_ctrl_timer), padapter->pnetdev, sitesurvey_ctrl_handler, padapter);
 	_init_timer(&(pmlmepriv->scan_to_timer), padapter->pnetdev, _rtw_scan_timeout_handler, padapter);
-
 	_init_timer(&(pmlmepriv->dynamic_chk_timer), padapter->pnetdev, _dynamic_check_timer_handlder, padapter);
-
 	#ifdef CONFIG_SET_SCAN_DENY_TIMER
 	_init_timer(&(pmlmepriv->set_scan_deny_timer), padapter->pnetdev, _rtw_set_scan_deny_timer_hdl, padapter);
 	#endif
+#else
+        timer_setup(&pmlmepriv->assoc_timer, rtw_join_timeout_handler, 0);
+        timer_setup(&pmlmepriv->scan_to_timer, _rtw_scan_timeout_handler, 0);
+        timer_setup(&pmlmepriv->dynamic_chk_timer, _dynamic_check_timer_handlder, 0);
+        #ifdef CONFIG_SET_SCAN_DENY_TIMER
+        timer_setup(&pmlmepriv->set_scan_deny_timer, _rtw_set_scan_deny_timer_hdl, 0);
+        #endif
+#endif
 
 #ifdef RTK_DMP_PLATFORM
 	_init_workitem(&(pmlmepriv->Linkup_workitem), Linkup_workitem_callback, padapter);
@@ -303,22 +340,44 @@ _func_exit_;
 
 }
 
-void _survey_timer_hdl (void *FunctionContext)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+static void _survey_timer_hdl(void *FunctionContext)
+#else
+static void _survey_timer_hdl(struct timer_list *t)
+#endif
 {
-	_adapter *padapter = (_adapter *)FunctionContext;
-	
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *padapter = (_adapter *)FunctionContext;
+#else
+        _adapter *padapter = from_timer(padapter, t, mlmeextpriv.survey_timer);
+#endif
 	survey_timer_hdl(padapter);
 }
 
-void _link_timer_hdl (void *FunctionContext)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+static void _link_timer_hdl (void *FunctionContext)
+#else
+static void _link_timer_hdl(struct timer_list *t)
+#endif
 {
-	_adapter *padapter = (_adapter *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _adapter *padapter = (_adapter *)FunctionContext;
+#else
+        _adapter *padapter = from_timer(padapter, t, mlmeextpriv.link_timer);
+#endif
 	link_timer_hdl(padapter);
 }
-
-void _addba_timer_hdl(void *FunctionContext)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+static void _addba_timer_hdl(void *FunctionContext)
+#else
+static void _addba_timer_hdl(struct timer_list *t)
+#endif
 {
-	struct sta_info *psta = (struct sta_info *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        struct sta_info *psta = (struct sta_info *)FunctionContext;
+#else
+        struct sta_info *psta = from_timer(psta, t, addba_retry_timer);
+#endif
 	addba_timer_hdl(psta);
 }
 
@@ -332,8 +391,11 @@ void _sa_query_timer_hdl (void *FunctionContext)
 
 void init_addba_retry_timer(_adapter *padapter, struct sta_info *psta)
 {
-
-	_init_timer(&psta->addba_retry_timer, padapter->pnetdev, _addba_timer_hdl, psta);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _init_timer(&psta->addba_retry_timer, padapter->pnetdev, _addba_timer_hdl, psta);
+#else
+        timer_setup(&psta->addba_retry_timer, _addba_timer_hdl, 0);
+#endif
 }
 
 /*
@@ -351,11 +413,16 @@ void _reassoc_timer_hdl(void *FunctionContext)
 */
 
 void init_mlme_ext_timer(_adapter *padapter)
-{	
+{
 	struct	mlme_ext_priv *pmlmeext = &padapter->mlmeextpriv;
 
-	_init_timer(&pmlmeext->survey_timer, padapter->pnetdev, _survey_timer_hdl, padapter);
-	_init_timer(&pmlmeext->link_timer, padapter->pnetdev, _link_timer_hdl, padapter);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        _init_timer(&pmlmeext->survey_timer, padapter->pnetdev, _survey_timer_hdl, padapter);
+        _init_timer(&pmlmeext->link_timer, padapter->pnetdev, _link_timer_hdl, padapter);
+#else
+        timer_setup(&pmlmeext->survey_timer, _survey_timer_hdl, 0);
+        timer_setup(&pmlmeext->link_timer, _link_timer_hdl, 0);
+#endif
 #ifdef CONFIG_IEEE80211W
 	_init_timer(&pmlmeext->sa_query_timer, padapter->pnetdev, _sa_query_timer_hdl, padapter);
 #endif //CONFIG_IEEE80211W

--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -431,18 +431,31 @@ void rtw_os_read_port(_adapter *padapter, struct recv_buf *precvbuf)
 #endif
 
 }
-void _rtw_reordering_ctrl_timeout_handler (void *FunctionContext);
-void _rtw_reordering_ctrl_timeout_handler (void *FunctionContext)
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+void _rtw_reordering_ctrl_timeout_handler(void *FunctionContext);
+void _rtw_reordering_ctrl_timeout_handler(void *FunctionContext)
+#else
+void _rtw_reordering_ctrl_timeout_handler(struct timer_list *t);
+void _rtw_reordering_ctrl_timeout_handler(struct timer_list *t)
+#endif
 {
-	struct recv_reorder_ctrl *preorder_ctrl = (struct recv_reorder_ctrl *)FunctionContext;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+        struct recv_reorder_ctrl *preorder_ctrl = (struct recv_reorder_ctrl *)FunctionContext;
+#else
+        struct recv_reorder_ctrl *preorder_ctrl = from_timer(preorder_ctrl, t, reordering_ctrl_timer);
+#endif
 	rtw_reordering_ctrl_timeout_handler(preorder_ctrl);
 }
 
 void rtw_init_recv_timer(struct recv_reorder_ctrl *preorder_ctrl)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
 	_adapter *padapter = preorder_ctrl->padapter;
 
 	_init_timer(&(preorder_ctrl->reordering_ctrl_timer), padapter->pnetdev, _rtw_reordering_ctrl_timeout_handler, preorder_ctrl);
-
+#else
+	timer_setup(&preorder_ctrl->reordering_ctrl_timer, _rtw_reordering_ctrl_timeout_handler, 0);
+#endif
 }
 


### PR DESCRIPTION
313eacc contains the material changes for the port to kernel 4.15.0.  These changes may merit a version bump in the driver itself so folks can determine at a glance if they have a 4.15.0 candidate module or not.  Your discretion.

I also think it worthwhile to update the README to reflect the fact that this 8192cu driver remains the superior option for many usb dongles that simply do not function well or at all with either the rtl8192cu driver or the rtl8xxxu driver.

Subsequent commits contain my attempts at communicating this, based in my forked repo.