### PR TITLE
Added PID for TP-Link TL-WN821N (usb)

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -162,6 +162,7 @@ static void rtw_dev_remove(struct usb_interface *pusb_intf);
 	{USB_DEVICE(0x050D, 0x1004)}, /* Belkin - Edimax */ \
 	{USB_DEVICE(0x0BDA, 0x2E2E)}, /* Intel - - */ \
 	{USB_DEVICE(0x2357, 0x0100)}, /* TP-Link - TP-Link */ \
+	{USB_DEVICE(0x2357, 0x0107)}, /* TP-Link -  TL-WN821 */ \
 	{USB_DEVICE(0x06F8, 0xE035)}, /* Hercules - Edimax */ \
 	{USB_DEVICE(0x04BB, 0x0950)}, /* IO-DATA - Edimax */ \
 	{USB_DEVICE(0x0DF6, 0x0070)}, /* Sitecom - Edimax */ \


### PR DESCRIPTION
For some reason, until kernel 4.14 this driver was working properly
but since last update to 4.15 the TL-WN821N was not being recognized.
Checking with lshw displayed that Realtek device was UNCLAIMED.
To solve this problem, I added PID 2357 VID 0107 to usb_intf.c list
and it start to work again.