### PR TITLE
Fixes for 4.19-rc1

### DIFF
--- a/include/wifi.h
+++ b/include/wifi.h
@@ -887,7 +887,9 @@ struct ADDBA_request
  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
  */
 #define IEEE80211_MIN_AMPDU_BUF 0x8
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 #define IEEE80211_MAX_AMPDU_BUF 0x40
+#endif
 
 
 /* Spatial Multiplexing Power Save Modes */

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -949,7 +949,11 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 	return dscp >> 5;
 }
 
-#if (LINUX_VERSION_CODE>=KERNEL_VERSION(3,14,0))
+#if (LINUX_VERSION_CODE>=KERNEL_VERSION(4,19,0))
+static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
+			    struct net_device *sb_dev,
+			    select_queue_fallback_t fallback)
+#elif (LINUX_VERSION_CODE>=KERNEL_VERSION(3,14,0))
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb,
 			    void *accel_priv,
 			    select_queue_fallback_t fallback)


### PR DESCRIPTION
Build tested (LibreELEC 9.0), but not run-time tested (no hardware).