### PR TITLE
Fix build error with clang

### DIFF
--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -1194,18 +1194,18 @@ enum ieee80211_state {
 (((Addr[2]) & 0xff) == 0xff) && (((Addr[3]) & 0xff) == 0xff) && (((Addr[4]) & 0xff) == 0xff) && \
 (((Addr[5]) & 0xff) == 0xff))
 #else
-extern __inline int is_multicast_mac_addr(const u8 *addr)
+static inline int is_multicast_mac_addr(const u8 *addr)
 {
         return ((addr[0] != 0xff) && (0x01 & addr[0]));
 }
 
-extern __inline int is_broadcast_mac_addr(const u8 *addr)
+static inline int is_broadcast_mac_addr(const u8 *addr)
 {
 	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
 		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
 }
 
-extern __inline int is_zero_mac_addr(const u8 *addr)
+static inline int is_zero_mac_addr(const u8 *addr)
 {
 	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
 		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));


### PR DESCRIPTION
This fixes the build error with clang similar to [1]:

ERROR: "is_broadcast_mac_addr" [drivers/net/wireless/realtek/rtl8192cu/8192cu.ko] undefined!
ERROR: "is_zero_mac_addr" [drivers/net/wireless/realtek/rtl8192cu/8192cu.ko] undefined!
ERROR: "is_multicast_mac_addr" [drivers/net/wireless/realtek/rtl8192cu/8192cu.ko] undefined!

[1] https://lore.kernel.org/patchwork/patch/1032558/