### PR TITLE
Update to kernel 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,106 +1,63 @@
 language: c
 compiler: gcc
-sudo: required
-dist: xenial
+dist: bionic
+os: linux
 
 before_install:
-  - export ALL_DEB=$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep -m1 all | cut -d '"' -f 2)
-  - export KVER_BUILD=$(echo $ALL_DEB | cut -d '_' -f 1 | cut -c15-)
-  - wget ${KERNEL_URL}v${KVER}/$(wget --quiet -O - ${KERNEL_URL}v${KVER}/ | grep -o 'href=".*"' | grep headers | grep generic | grep -m1 amd64 | cut -d '"' -f 2)
-  - wget ${KERNEL_URL}v${KVER}/$ALL_DEB
+  #Cron builds only build mainline kernel. Stable and LTS kernels usually not have breaking changes.
+  - if [ "$TRAVIS_EVENT_TYPE" == "cron" ] && [ "$KVER_BUILD" != "$KERNEL_MAINLINE" ]; then exit 0; fi
+  - export KERNEL_URL_DETAILS=$(wget --quiet -O - ${KERNEL_URL}v${KVER_BUILD}/ | grep -A8 "Build for ${TRAVIS_CPU_ARCH}\|Test ${TRAVIS_CPU_ARCH}")
+  - export ALL_DEB=$(echo "$KERNEL_URL_DETAILS" |  grep -m1 'all.deb' | cut -d '"' -f 2)
+  - export KVER=$(echo $ALL_DEB | cut -d '_' -f 2 | rev | cut -c14- | rev)-generic
+  - wget ${KERNEL_URL}v${KVER_BUILD}/$(echo "$KERNEL_URL_DETAILS" | grep -m1 "${TRAVIS_CPU_ARCH}.deb" | cut -d '"' -f 2)
+  - wget ${KERNEL_URL}v${KVER_BUILD}/$ALL_DEB
   - sudo dpkg -i *.deb
 
-script:
-  - make CC=$COMPILER KVER=$KVER_BUILD-generic
+script: make CC=$CC KVER=$KVER
+
+addons:
+  apt:
+    packages:
+      #Force update to GCC-7.5 in order to compile Kernels >= 5.4.
+      - gcc-7
 env:
   global:
-    - KERNEL_URL=http://kernel.ubuntu.com/~kernel-ppa/mainline/
+    - KERNEL_URL=https://kernel.ubuntu.com/~kernel-ppa/mainline/
+    - KERNEL_MAINLINE=$(curl -s https://www.kernel.org/releases.json | grep -B1 'mainline' | head -1 | cut -d'"' -f4)
+    - KERNEL_STABLE=$(curl -s https://www.kernel.org/releases.json | grep -A1 'latest_stable' | tail -1 | cut -d'"' -f4)
+  jobs:
+    - KVER_BUILD=$KERNEL_MAINLINE
+    - KVER_BUILD=$KERNEL_STABLE
+    - KVER_BUILD=5.5.19 #EOL
+ #Kernels 5.4 with minor versions > 28 are failing on amd64. Not upgrade the minor version without check https://kernel.ubuntu.com/~kernel-ppa/mainline/ 
+    - KVER_BUILD=5.4.28
+    - KVER_BUILD=4.19.131
+    - KVER_BUILD=4.14.187
+    - KVER_BUILD=4.9.229
+    - KVER_BUILD=4.4.229
+    - KVER_BUILD=3.16.84
+cache:
+  - ccache: true
 
-matrix:
+jobs:
+#Mainline kernel is also compiled on GCC 8, 9 and 10. Jobs are added to the build matrix expansion
   include:
-    - compiler: gcc
-      addons:
+    - addons:
         apt:
           sources:
-            - sourceline: 'ppa:ondrej/nginx-mainline'
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
-            - libssl1.1
-      env: COMPILER=gcc-5 KVER=5.3.5
-    - compiler: gcc
-      addons:
+            - gcc-10
+      env: CC=gcc-10 KVER_BUILD=$KERNEL_MAINLINE
+    - addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
-            - gcc-6
-            - libssl1.1
-      env: COMPILER=gcc-6 KVER=5.3.5
-    - compiler: gcc
-      addons:
+            - gcc-9
+      env: CC=gcc-9 KVER_BUILD=$KERNEL_MAINLINE
+    - addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
-            - gcc-7
-            - libssl1.1
-      env: COMPILER=gcc-7 KVER=5.3.5
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - libssl1.1
-      env: COMPILER=gcc-5 KVER=5.2.20
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-6
-            - libssl1.1
-      env: COMPILER=gcc-6 KVER=5.2.20
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-7
-            - libssl1.1
-      env: COMPILER=gcc-7 KVER=5.2.20
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - libssl1.1
-      env: COMPILER=gcc-5 KVER=4.19.45
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-6
-            - libssl1.1
-      env: COMPILER=gcc-6 KVER=4.19.45
-    - compiler: gcc
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - sourceline: 'ppa:ondrej/nginx-mainline'
-          packages:
-            - gcc-7
-            - libssl1.1
-      env: COMPILER=gcc-7 KVER=4.19.45
-    - compiler: gcc
-      env: COMPILER=gcc-5 KVER=3.14.79
+            - gcc-8
+      env: CC=gcc-8 KVER_BUILD=$KERNEL_MAINLINE

--- a/core/rtw_security.c
+++ b/core/rtw_security.c
@@ -2153,7 +2153,7 @@ BIP_exit:
 
 #ifndef PLATFORM_FREEBSD
 /* compress 512-bits */
-static int sha256_compress(struct sha256_state *md, unsigned char *buf)
+static int sha256_compress(struct rtw_sha256_state *md, unsigned char *buf)
 {
 	u32 S[8], W[64], t0, t1;
 	u32 t;
@@ -2195,7 +2195,7 @@ static int sha256_compress(struct sha256_state *md, unsigned char *buf)
 }
 
 /* Initialize the hash state */
-static void sha256_init(struct sha256_state *md)
+static void sha256_init(struct rtw_sha256_state *md)
 {
 	md->curlen = 0;
 	md->length = 0;
@@ -2216,7 +2216,7 @@ static void sha256_init(struct sha256_state *md)
    @param inlen  The length of the data (octets)
    @return CRYPT_OK if successful
 */
-static int sha256_process(struct sha256_state *md, unsigned char *in,
+static int sha256_process(struct rtw_sha256_state *md, unsigned char *in,
 			  unsigned long inlen)
 {
 	unsigned long n;
@@ -2257,7 +2257,7 @@ static int sha256_process(struct sha256_state *md, unsigned char *in,
    @param out [out] The destination of the hash (32 bytes)
    @return CRYPT_OK if successful
 */
-static int sha256_done(struct sha256_state *md, unsigned char *out)
+static int sha256_done(struct rtw_sha256_state *md, unsigned char *out)
 {
 	int i;
 
@@ -2309,7 +2309,7 @@ static int sha256_done(struct sha256_state *md, unsigned char *out)
 static int sha256_vector(size_t num_elem, u8 *addr[], size_t *len,
 		  u8 *mac)
 {
-	struct sha256_state ctx;
+	struct rtw_sha256_state ctx;
 	size_t i;
 
 	sha256_init(&ctx);

--- a/include/rtw_security.h
+++ b/include/rtw_security.h
@@ -195,7 +195,7 @@ struct security_priv
 	u8 bWepDefaultKeyIdxSet;
 };
 
-struct sha256_state {
+struct rtw_sha256_state {
 	u64 length;
 	u32 state[8], curlen;
 	u8 buf[64];

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -4852,6 +4852,7 @@ exit:
 	return ret;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
 static void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0))
 	struct wireless_dev *wdev,
@@ -4872,6 +4873,7 @@ static void cfg80211_rtw_mgmt_frame_register(struct wiphy *wiphy,
 
 	return;
 }
+#endif
 
 static int rtw_cfg80211_set_beacon_wpsp2pie(struct net_device *ndev, char *buf, int len)
 {	
@@ -5290,7 +5292,9 @@ static struct cfg80211_ops rtw_cfg80211_ops = {
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,37)) || defined(COMPAT_KERNEL_RELEASE)	 
 	.mgmt_tx = cfg80211_rtw_mgmt_tx,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
 	.mgmt_frame_register = cfg80211_rtw_mgmt_frame_register,
+#endif
 #elif  (LINUX_VERSION_CODE>=KERNEL_VERSION(2,6,34) && LINUX_VERSION_CODE<=KERNEL_VERSION(2,6,35))
 	.action = cfg80211_rtw_mgmt_tx,
 #endif


### PR DESCRIPTION
Fix the compilation issues with kernel 5.8
Update the Travis build to lasts LTS kernels.
Mainline and stable versions are fetch from https://www.kernel.org/ dynamically in order to avoid change the file every time that a new kernel version is released.
