### PR TITLE
Raspberry Pi Makefile support based on Mange/rtl8192eu-linux-driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ CONFIG_RTL8192CU_REDEFINE_1X1 = n
 CONFIG_INTEL_WIDI = n
 CONFIG_WAKE_ON_WLAN = n
 
+CONFIG_PLATFORM_ARM_RPI = n
 CONFIG_PLATFORM_I386_PC = y
 CONFIG_PLATFORM_TI_AM3517 = n
 CONFIG_PLATFORM_ANDROID_X86 = n
@@ -245,6 +246,16 @@ KVER  := $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
+endif
+
+ifeq ($(CONFIG_PLATFORM_ARM_RPI), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
+ARCH := arm
+CROSS_COMPILE :=
+KVER  := $(shell uname -r)
+KSRC ?= /lib/modules/$(KVER)/build
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 endif
 
 ifeq ($(CONFIG_PLATFORM_TI_AM3517), y)


### PR DESCRIPTION
Hi,

I've modified the Makefile to add a Raspberry Pi target platform, copied from Mange/rtl8192eu-linux-driver

I've tested it in a Raspberry Pi 2 running OSMC, kernel version 4.19.122. DKMS build fails for unknown reasons, but that's probably because of my build environment.

Thanks!